### PR TITLE
Replace object spread with Object.assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,7 +279,7 @@ function remarkAttr(userConfig) {
     scope: 'extended',
     mdAttrConfig: undefined,
   };
-  const config = {...defaultConfig, ...userConfig};
+  const config = Object.assign({}, defaultConfig, userConfig);
 
   if (!isRemarkParser(parser)) {
     throw new Error('Missing parser to attach `remark-attr` [link] (to)');


### PR DESCRIPTION
The object spread operator is not currently supported in MS Edge (I know :( ).  That makes any site I build that includes remark-attr crash on Edge.  I'm hesitant to submit this PR because it should be something I can handle in my build pipe... but I'm having no luck with Angular CLI... which can be pretty opinionated in its build process.

I know it is ugly but would appreciate this change... Thanks.