### PR TITLE
`atxHeading` -> `heading`

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ An object that extends the list of attributes supported for some elements.
 Example : 
 
 ```
-extend: {atxHeading: ['original', 'quality', 'format', 'toc']}
+extend: {heading: ['original', 'quality', 'format', 'toc']}
 ```
 
 With this configuration, if the scope permits it, 4 mores attributes will be supported for atxHeading elements.


### PR DESCRIPTION
Hello! I noticed a little mistake in the readme.

This is not working: `{ atxHeading: ['attr'] }`
This is ok: `{ heading: ['attr'] }`

Because there is no such type

```
const convTypeTag = {
  image: "img",
  link: "a",
  heading: "h1",
  strong: "strong",
  emphasis: "em",
  delete: "s",
  inlineCode: "code",
  code: "code",
  "*": "*"
};
```